### PR TITLE
Fixed trailing CRLF on Session ID

### DIFF
--- a/lib/tropo_rest/client/session.rb
+++ b/lib/tropo_rest/client/session.rb
@@ -13,7 +13,9 @@ module TropoRest
       def create_session(token, params={})
         params.merge!('token' => token)
         params.merge!(params) { |k,v| v.to_s } # custom parameters must be strings
-        post(PLURAL_PATH, params)
+        response = post(PLURAL_PATH, params)
+        response.id = response.id.strip if response.id
+        response
       end
 
     end


### PR DESCRIPTION
Previously when calling create_session, the returned session ID contained a carriage return & line feed (\n\r) which had to be stripped before using it. This patch fixes it by stripping it when returning the hash.

I haven't added tests because I couldn't figure out how to work the stubbing.
